### PR TITLE
add metadata fields as commandline parameters for pack

### DIFF
--- a/upack/Command.cs
+++ b/upack/Command.cs
@@ -258,6 +258,17 @@ namespace Inedo.ProGet.UPack
             }
         }
 
+        internal static async Task CreateEntryFromStreamAsync(ZipArchive zipFile, Stream file, string entryPath)
+        {
+            var entry = zipFile.CreateEntry(entryPath);
+            
+            using (var output = entry.Open())
+            {
+                file.Position = 0;
+                await file.CopyToAsync(output);
+            }
+        }
+
         internal static async Task AddDirectoryAsync(ZipArchive zipFile, string sourceDirectory, string entryRootPath)
         {
             bool hasContent = false;

--- a/upack/Pack.cs
+++ b/upack/Pack.cs
@@ -2,6 +2,8 @@
 using System.ComponentModel;
 using System.IO;
 using System.IO.Compression;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
 using System.Threading.Tasks;
 
 namespace Inedo.ProGet.UPack
@@ -12,12 +14,12 @@ namespace Inedo.ProGet.UPack
     {
         [DisplayName("metadata")]
         [Description("Path of a valid upack.json metadata file.")]
-        [PositionalArgument(0)]
+        [ExtraArgument]
         public string Manifest { get; set; }
 
         [DisplayName("source")]
         [Description("Directory containing files to add to the package.")]
-        [PositionalArgument(1)]
+        [PositionalArgument(0)]
         public string SourceDirectory { get; set; }
 
         [DisplayName("targetDirectory")]
@@ -25,24 +27,85 @@ namespace Inedo.ProGet.UPack
         [ExtraArgument]
         public string TargetDirectory { get; set; }
 
+        [DisplayName("group")]
+        [Description("Package group. If metadata file is provided, value will be ignored.")]
+        [ExtraArgument]
+        public string Group { get; set; }
+
+        [DisplayName("name")]
+        [Description("Package name. If metadata file is provided, value will be ignored.")]
+        [ExtraArgument]
+        public string Name { get; set; }
+
+        [DisplayName("version")]
+        [Description("Package version. If metadata file is provided, value will be ignored.")]
+        [ExtraArgument]
+        public string Version { get; set; }
+
+        [DisplayName("title")]
+        [Description("Package title. If metadata file is provided, value will be ignored.")]
+        [ExtraArgument]
+        public string Title { get; set; }
+
+        [DisplayName("description")]
+        [Description("Package description. If metadata file is provided, value will be ignored.")]
+        [ExtraArgument]
+        public string PackageDescription { get; set; }
+
+        [DisplayName("icon")]
+        [Description("Icon absolute Url. If metadata file is provided, value will be ignored.")]
+        [ExtraArgument]
+        public string IconUrl { get; set; }
+
+
         public override async Task<int> RunAsync()
         {
             this.TargetDirectory = this.TargetDirectory ?? Environment.CurrentDirectory;
 
             PackageMetadata info;
+            bool useMetadata = false;
 
-            using (var metadataStream = File.OpenRead(this.Manifest))
+            if (string.IsNullOrWhiteSpace(this.Manifest))
             {
-                info = await ReadManifestAsync(metadataStream);
+                info = new PackageMetadata
+                {
+                    Group = this.Group,
+                    Name = this.Name,
+                    Version = this.Version,
+                    Title = this.Title,
+                    Description = this.PackageDescription,
+                    IconUrl = this.IconUrl
+                };
+            }
+            else
+            {
+                useMetadata = true;
+                using (var metadataStream = File.OpenRead(this.Manifest))
+                {
+                    info = await ReadManifestAsync(metadataStream);
+                }
             }
 
             PrintManifest(info);
+
+            var serializer = new DataContractJsonSerializer(typeof(PackageMetadata));
 
             var fileName = Path.Combine(this.TargetDirectory, $"{info.Name}-{info.BareVersion}.upack");
             using (var zipStream = new FileStream(fileName, FileMode.Create, FileAccess.Write))
             using (var zipFile = new ZipArchive(zipStream, ZipArchiveMode.Create, true))
             {
-                await CreateEntryFromFileAsync(zipFile, this.Manifest, "upack.json");
+                if (useMetadata)
+                    await CreateEntryFromFileAsync(zipFile, this.Manifest, "upack.json");
+                else
+                    await Task.Run(async () =>
+                    {
+                        using (var metadata = new MemoryStream())
+                        {
+                            serializer.WriteObject(metadata, info);
+                            await CreateEntryFromStreamAsync(zipFile, metadata, "upack.json");
+                        }
+                    });
+                
                 await AddDirectoryAsync(zipFile, this.SourceDirectory, "package/");
             }
 


### PR DESCRIPTION
pack command currently requires a metadata file to create a universal package. This pull request adds command line parameters to allow build tools to provide parameters without creating a upack.json file first.