### PR TITLE
Add experimental build-dependency-tree command.

### DIFF
--- a/build_dependency_tree.go
+++ b/build_dependency_tree.go
@@ -1,0 +1,585 @@
+package main
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type BuildDependencyTree struct {
+	PackageName     string
+	Version         string
+	SourceURL       string
+	TargetDirectory *string
+	Authentication  *[2]string
+	Overwrite       bool
+	Prerelease      bool
+	Comment         *string
+	UserRegistry    bool
+	Unregistered    bool
+	CachePackages   bool
+
+	registry Registry
+	cache    Registry
+}
+
+type ResolvedDependencyInfo struct {
+	Packages []*ResolvedDependencyPackage
+	Dirs     map[string]struct{}
+	Files    map[string][sha256.Size]byte
+}
+
+type ResolvedDependencyPackage struct {
+	PackageName string
+	Version     *UniversalPackageVersion
+}
+
+type DependencyTree struct {
+	PackageName  string
+	Version      *UniversalPackageVersion
+	Dependencies []*DependencyTree
+	Dirs         map[string]struct{}
+	Files        map[string][sha256.Size]byte
+}
+
+func (*BuildDependencyTree) Name() string { return "build-dependency-tree" }
+func (*BuildDependencyTree) Description() string {
+	return "[Experimental] Download a package with all of its dependencies, recursively. Behavior subject to change."
+}
+
+func (b *BuildDependencyTree) Help() string  { return defaultCommandHelp(b) }
+func (b *BuildDependencyTree) Usage() string { return defaultCommandUsage(b) }
+
+func (*BuildDependencyTree) PositionalArguments() []PositionalArgument {
+	return []PositionalArgument{
+		{
+			Name:        "package",
+			Description: "Package name and group, such as group/name.",
+			Index:       0,
+			TrySetValue: trySetStringValue("package", func(cmd Command) *string {
+				return &cmd.(*BuildDependencyTree).PackageName
+			}),
+		},
+		{
+			Name:        "version",
+			Description: "Package version. If not specified, the latest version is retrieved.",
+			Index:       1,
+			Optional:    true,
+			TrySetValue: trySetStringValue("version", func(cmd Command) *string {
+				return &cmd.(*BuildDependencyTree).Version
+			}),
+		},
+	}
+}
+
+func (*BuildDependencyTree) ExtraArguments() []ExtraArgument {
+	return []ExtraArgument{
+		{
+			Name:        "source",
+			Description: "URL of a upack API endpoint.",
+			Required:    true,
+			TrySetValue: trySetStringValue("source", func(cmd Command) *string {
+				return &cmd.(*BuildDependencyTree).SourceURL
+			}),
+		},
+		{
+			Name:        "target",
+			Description: "Directory where the contents of the package will be extracted. If not specified, the packages will be listed but not installed.",
+			TrySetValue: trySetStringValue("target", func(cmd Command) *string {
+				target := new(string)
+				cmd.(*BuildDependencyTree).TargetDirectory = target
+				return target
+			}),
+		},
+		{
+			Name:        "user",
+			Description: "User name and password to use for servers that require authentication. Example: username:password",
+			TrySetValue: trySetBasicAuthValue("user", func(cmd Command) **[2]string {
+				return &cmd.(*BuildDependencyTree).Authentication
+			}),
+		},
+		{
+			Name:        "overwrite",
+			Description: "When specified, Overwrite files in the target directory.",
+			Flag:        true,
+			TrySetValue: trySetBoolValue("overwrite", func(cmd Command) *bool {
+				return &cmd.(*BuildDependencyTree).Overwrite
+			}),
+		},
+		{
+			Name:        "prerelease",
+			Description: "When version is not specified, will install the latest prerelase version instead of the latest stable version.",
+			Flag:        true,
+			TrySetValue: trySetBoolValue("prerelease", func(cmd Command) *bool {
+				return &cmd.(*BuildDependencyTree).Prerelease
+			}),
+		},
+		{
+			Name:        "comment",
+			Description: "The reason for installing the package, for the local registry.",
+			TrySetValue: trySetStringValue("comment", func(cmd Command) *string {
+				s := new(string)
+				cmd.(*BuildDependencyTree).Comment = s
+				return s
+			}),
+		},
+		{
+			Name:        "userregistry",
+			Description: "Register the package in the user registry instead of the machine registry.",
+			Flag:        true,
+			TrySetValue: trySetBoolValue("userregistry", func(cmd Command) *bool {
+				return &cmd.(*BuildDependencyTree).UserRegistry
+			}),
+		},
+		{
+			Name:        "unregistered",
+			Description: "Do not register the package in a local registry.",
+			Flag:        true,
+			TrySetValue: trySetBoolValue("unregistered", func(cmd Command) *bool {
+				return &cmd.(*BuildDependencyTree).Unregistered
+			}),
+		},
+		{
+			Name:        "cache",
+			Description: "Cache the contents of the package in the local registry.",
+			Flag:        true,
+			TrySetValue: trySetBoolValue("cache", func(cmd Command) *bool {
+				return &cmd.(*BuildDependencyTree).CachePackages
+			}),
+		},
+	}
+}
+
+func (b *BuildDependencyTree) Run() int {
+	if b.Unregistered {
+		b.registry = Unregistered
+	} else if b.UserRegistry {
+		b.registry = User
+	} else {
+		b.registry = Machine
+	}
+
+	if b.CachePackages {
+		b.cache = b.registry
+	} else {
+		dir, err := ioutil.TempDir("", "upack")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		defer os.RemoveAll(dir)
+		b.cache = Registry(dir)
+	}
+
+	tree, err := b.BuildTree(b.PackageName, b.Version, b.Prerelease)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	resolved, err := b.Resolve(tree)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	if b.TargetDirectory != nil {
+		if !b.Overwrite && b.CheckOverwrite(resolved) {
+			return 1
+		}
+
+		for _, pkg := range resolved.Packages {
+			fmt.Printf("Extracting %s:%v...\n", pkg.PackageName, pkg.Version)
+
+			err = b.ExtractPackage(pkg)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return 1
+			}
+		}
+	} else {
+		for _, pkg := range resolved.Packages {
+			fmt.Printf("%s:%v\n", pkg.PackageName, pkg.Version)
+		}
+	}
+
+	return 0
+}
+
+func (b *BuildDependencyTree) CheckOverwrite(resolved *ResolvedDependencyInfo) bool {
+	found := false
+
+	for name := range resolved.Dirs {
+		fi, err := os.Stat(filepath.Join(*b.TargetDirectory, name))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "when checking directory %q: %v\n", name, err)
+			found = true
+		} else if !fi.IsDir() {
+			fmt.Fprintf(os.Stderr, "refusing to overwrite file with directory: %q\n", name)
+			found = true
+		}
+	}
+
+	for name := range resolved.Files {
+		fi, err := os.Stat(filepath.Join(*b.TargetDirectory, name))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "when checking file %q: %v\n", name, err)
+			found = true
+		} else if fi.IsDir() {
+			fmt.Fprintf(os.Stderr, "refusing to overwrite directory with file: %q\n", name)
+			found = true
+		} else {
+			fmt.Fprintf(os.Stderr, "refusing to overwrite file: %q\n", name)
+			found = true
+		}
+	}
+
+	return found
+}
+
+func (b *BuildDependencyTree) ExtractPackage(pkg *ResolvedDependencyPackage) (err error) {
+	r, size, done, err := b.OpenPackage(pkg.PackageName, pkg.Version.String(), false)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if e := done(); err == nil {
+			err = e
+		}
+	}()
+
+	zipFile, err := zip.NewReader(r, size)
+	if err != nil {
+		return err
+	}
+
+	return UnpackZip(*b.TargetDirectory, true, zipFile)
+}
+
+func (b *BuildDependencyTree) Resolve(tree *DependencyTree) (*ResolvedDependencyInfo, error) {
+	maxDepth := b.ComputeMaxDepth(tree)
+
+	info := &ResolvedDependencyInfo{}
+	for depth := maxDepth; depth >= 0; depth-- {
+		info.Packages = b.GatherPackages(tree, depth, info.Packages)
+	}
+
+	var err error
+	info.Dirs, info.Files, err = b.MergeContents(tree)
+	return info, err
+}
+
+func (b *BuildDependencyTree) ComputeMaxDepth(tree *DependencyTree) int {
+	depth := 0
+
+	for _, d := range tree.Dependencies {
+		if childDepth := b.ComputeMaxDepth(d); childDepth >= depth {
+			depth = childDepth + 1
+		}
+	}
+
+	return depth
+}
+
+func (b *BuildDependencyTree) GatherPackages(tree *DependencyTree, depth int, packages []*ResolvedDependencyPackage) []*ResolvedDependencyPackage {
+	if depth > 0 {
+		for _, d := range tree.Dependencies {
+			packages = b.GatherPackages(d, depth-1, packages)
+		}
+		return packages
+	}
+
+	for i, p := range packages {
+		if p.PackageName == tree.PackageName && p.Version.Equals(tree.Version) {
+			packages = append(packages[:i], packages[i+1:]...)
+			break
+		}
+	}
+
+	return append(packages, &ResolvedDependencyPackage{
+		PackageName: tree.PackageName,
+		Version:     tree.Version,
+	})
+}
+
+func (b *BuildDependencyTree) MergeContents(tree *DependencyTree) (map[string]struct{}, map[string][sha256.Size]byte, error) {
+	depDirs := make([]map[string]struct{}, len(tree.Dependencies))
+	depFiles := make([]map[string][sha256.Size]byte, len(tree.Dependencies))
+
+	for i, d := range tree.Dependencies {
+		var err error
+		depDirs[i], depFiles[i], err = b.MergeContents(d)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "in dependency of %s:%v", tree.PackageName, tree.Version)
+		}
+	}
+
+	fileFrom := make(map[string]int)
+	mergedFiles := make(map[string][sha256.Size]byte)
+
+	for i, df := range depFiles {
+		d := tree.Dependencies[i]
+		for name, hash := range df {
+			if _, ok := tree.Files[name]; ok {
+				continue
+			}
+
+			if existingHash, ok := mergedFiles[name]; ok {
+				if existingHash == hash {
+					continue
+				}
+
+				existing := tree.Dependencies[fileFrom[name]]
+				return nil, nil, errors.Errorf("Cannot have both %s:%v and %s:%v as dependencies of %s:%v as both contain the file %q with different hashes (%x vs %x)", existing.PackageName, existing.Version, d.PackageName, d.Version, tree.PackageName, tree.Version, name, existingHash, hash)
+			}
+
+			mergedFiles[name] = hash
+			fileFrom[name] = i
+		}
+	}
+
+	for name, hash := range tree.Files {
+		mergedFiles[name] = hash
+	}
+
+	mergedDirs := make(map[string]struct{})
+	dirFrom := make(map[string]int)
+
+	for name := range tree.Dirs {
+		mergedDirs[name] = struct{}{}
+	}
+
+	for i, dd := range depDirs {
+		for name := range dd {
+			if _, ok := mergedDirs[name]; !ok {
+				mergedDirs[name] = struct{}{}
+				dirFrom[name] = i
+			}
+		}
+	}
+
+	for name := range mergedDirs {
+		if _, ok := mergedFiles[name]; ok {
+			dirTree := tree
+			if i, ok := dirFrom[name]; ok {
+				dirTree = tree.Dependencies[i]
+			}
+			fileTree := tree
+			if i, ok := fileFrom[name]; ok {
+				fileTree = tree.Dependencies[i]
+			}
+			return nil, nil, errors.Errorf("Cannot have both a directory from %s:%v and a file from %s:%v named %q in %s:%v", dirTree.PackageName, dirTree.Version, fileTree.PackageName, fileTree.Version, name, tree.PackageName, tree.Version)
+		}
+	}
+
+	return mergedDirs, mergedFiles, nil
+}
+
+func (b *BuildDependencyTree) BuildTree(name, version string, prerelease bool) (*DependencyTree, error) {
+	manifest, dirs, files, err := b.ReadUpack(name, version, prerelease)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedName := manifest.groupAndName()
+	resolvedVersion, err := ParseUniversalPackageVersion(manifest.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	tree := &DependencyTree{
+		PackageName:  resolvedName,
+		Version:      resolvedVersion,
+		Dependencies: make([]*DependencyTree, len(manifest.Dependencies)),
+		Files:        files,
+		Dirs:         dirs,
+	}
+
+	prerelease = resolvedVersion.Prerelease != ""
+
+	for i, d := range manifest.Dependencies {
+		parts := strings.SplitN(d, ":", 3)
+		switch len(parts) {
+		case 1:
+			name = parts[0]
+			version = ""
+		case 2:
+			if parts[1] == "*" {
+				name = parts[0]
+				version = ""
+			} else if parsedVersion, err := ParseUniversalPackageVersion(parts[1]); err == nil {
+				name = parts[0]
+				version = parsedVersion.String()
+			} else {
+				name = parts[0] + "/" + parts[1]
+				version = ""
+			}
+		case 3:
+			name = parts[0] + "/" + parts[1]
+			if parts[2] == "*" {
+				version = ""
+			} else {
+				version = parts[2]
+			}
+		}
+		tree.Dependencies[i], err = b.BuildTree(name, version, prerelease)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return tree, nil
+}
+
+func (b *BuildDependencyTree) ReadUpack(name, version string, prerelease bool) (manifest *PackageMetadata, dirs map[string]struct{}, files map[string][sha256.Size]byte, err error) {
+	r, size, done, err := b.OpenPackage(name, version, prerelease)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	defer func() {
+		if e := done(); err == nil {
+			err = e
+		}
+	}()
+
+	zip, err := zip.NewReader(r, size)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	dirs = make(map[string]struct{})
+	files = make(map[string][sha256.Size]byte)
+
+	for _, f := range zip.File {
+		if f.Name == "upack.json" {
+			manifest, err = b.ReadManifest(f)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		}
+		name := strings.Replace(f.Name, "\\", "/", -1)
+		if !strings.HasPrefix(name, "package/") {
+			continue
+		}
+		name = strings.TrimRight(name[len("package/"):], "/")
+		if name == "" {
+			continue
+		}
+		if f.Mode().IsDir() {
+			dirs[name] = struct{}{}
+		} else {
+			hash, err := b.ComputeHash(f)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			files[name] = hash
+		}
+		for {
+			i := strings.LastIndex(name, "/")
+			if i == -1 {
+				break
+			}
+			name = name[:i]
+			dirs[name] = struct{}{}
+		}
+	}
+
+	return manifest, dirs, files, nil
+}
+
+func (b *BuildDependencyTree) ReadManifest(f *zip.File) (manifest *PackageMetadata, err error) {
+	r, err := f.Open()
+	if err != nil {
+		return
+	}
+	defer func() {
+		if e := r.Close(); err == nil {
+			err = e
+		}
+	}()
+
+	return ReadManifest(r)
+}
+
+func (b *BuildDependencyTree) ComputeHash(f *zip.File) (hash [sha256.Size]byte, err error) {
+	r, err := f.Open()
+	if err != nil {
+		return
+	}
+	defer func() {
+		if e := r.Close(); err == nil {
+			err = e
+		}
+	}()
+
+	h := sha256.New()
+	_, err = io.Copy(h, r)
+	if err != nil {
+		return
+	}
+
+	h.Sum(hash[:0])
+	return
+}
+
+func (b *BuildDependencyTree) OpenPackage(packageName, packageVersion string, prerelease bool) (io.ReaderAt, int64, func() error, error) {
+	var group, name string
+	var version *UniversalPackageVersion
+
+	parts := strings.Split(strings.Replace(packageName, ":", "/", -1), "/")
+	if len(parts) == 1 {
+		name = parts[0]
+	} else {
+		group = strings.Join(parts[:len(parts)-1], "/")
+		name = parts[len(parts)-1]
+	}
+
+	versionString, err := GetVersion(b.SourceURL, group, name, packageVersion, b.Authentication, prerelease)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	version, err = ParseUniversalPackageVersion(versionString)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	var userName *string
+	u, err := user.Current()
+	if err == nil {
+		userName = &u.Username
+	}
+
+	if b.TargetDirectory != nil {
+		err = b.registry.RegisterPackage(group, name, version, *b.TargetDirectory, b.SourceURL, b.Authentication, b.Comment, nil, userName)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+	}
+
+	f, done, err := b.cache.GetOrDownload(group, name, version, b.SourceURL, b.Authentication, true)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		_ = done()
+		return nil, 0, nil, err
+	}
+
+	return f, fi.Size(), done, nil
+}

--- a/command_dispatcher.go
+++ b/command_dispatcher.go
@@ -12,6 +12,7 @@ var commands = CommandDispatcher{
 	&Unpack{},
 	&Install{},
 	&List{},
+	&BuildDependencyTree{},
 }
 
 type CommandDispatcher []Command

--- a/upack/BuildDependencyTree.cs
+++ b/upack/BuildDependencyTree.cs
@@ -1,0 +1,471 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace Inedo.ProGet.UPack
+{
+    [DisplayName("build-dependency-tree")]
+    [Description("[Experimental] Download a package with all of its dependencies, recursively. Behavior subject to change.")]
+    public sealed class BuildDependencyTree : Command
+    {
+        [DisplayName("package")]
+        [Description("Package name and group, such as group/name.")]
+        [PositionalArgument(0)]
+        public string PackageName { get; set; }
+
+        [DisplayName("version")]
+        [Description("Package version. If not specified, the latest version is retrieved.")]
+        [PositionalArgument(1, Optional = true)]
+        public string Version { get; set; }
+
+        [DisplayName("source")]
+        [Description("URL of a upack API endpoint.")]
+        [ExtraArgument(Optional = false)]
+        public string SourceUrl { get; set; }
+
+        [DisplayName("target")]
+        [Description("Directory where the contents of the package will be extracted. If not specified, the packages will be listed but not installed.")]
+        [ExtraArgument]
+        public string TargetDirectory { get; set; }
+
+        [DisplayName("user")]
+        [Description("User name and password to use for servers that require authentication. Example: username:password")]
+        [ExtraArgument]
+        public NetworkCredential Authentication { get; set; }
+
+        [DisplayName("overwrite")]
+        [Description("When specified, Overwrite files in the target directory.")]
+        [ExtraArgument]
+        [DefaultValue(false)]
+        public bool Overwrite { get; set; } = false;
+
+        [DisplayName("prerelease")]
+        [Description("When version is not specified, will install the latest prerelase version instead of the latest stable version.")]
+        [ExtraArgument]
+        [DefaultValue(false)]
+        public bool Prerelease { get; set; } = false;
+
+        [DisplayName("comment")]
+        [Description("The reason for installing the package, for the local registry.")]
+        [ExtraArgument]
+        public string Comment { get; set; }
+
+        [DisplayName("userregistry")]
+        [Description("Register the package in the user registry instead of the machine registry.")]
+        [ExtraArgument]
+        [DefaultValue(false)]
+        public bool UserRegistry { get; set; } = false;
+
+        [DisplayName("unregistered")]
+        [Description("Do not register the package in a local registry.")]
+        [ExtraArgument]
+        [DefaultValue(false)]
+        public bool Unregistered { get; set; } = false;
+
+        [DisplayName("cache")]
+        [Description("Cache the contents of the package in the local registry.")]
+        [ExtraArgument]
+        [DefaultValue(false)]
+        public bool CachePackages { get; set; } = false;
+
+        private Registry registry, cache;
+
+        public override async Task<int> RunAsync()
+        {
+            if (this.Unregistered)
+            {
+                this.registry = Registry.Unregistered;
+            }
+            else if (this.UserRegistry)
+            {
+                this.registry = Registry.User;
+            }
+            else
+            {
+                this.registry = Registry.Machine;
+            }
+
+            string tempCacheRegistry = null;
+            if (this.CachePackages)
+            {
+                this.cache = this.registry;
+            }
+            else
+            {
+                tempCacheRegistry = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                this.cache = new Registry(tempCacheRegistry);
+            }
+
+            try
+            {
+                var tree = await this.BuildTreeAsync(this.PackageName, this.Version, this.Prerelease);
+                var resolved = this.Resolve(tree);
+                if (this.TargetDirectory != null)
+                {
+                    if (!this.Overwrite && this.CheckOverwrite(resolved))
+                    {
+                        return 1;
+                    }
+
+                    foreach (var pkg in resolved.Packages)
+                    {
+                        Console.WriteLine($"Extracting {pkg.PackageName}:{pkg.Version}...");
+
+                        using (var stream = await this.OpenPackageAsync(pkg.PackageName, pkg.Version.ToString(), false))
+                        using (var zip = new ZipArchive(stream, ZipArchiveMode.Read, true))
+                        {
+                            await UnpackZipAsync(this.TargetDirectory, true, zip);
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var pkg in resolved.Packages)
+                    {
+                        Console.WriteLine($"{pkg.PackageName}:{pkg.Version}");
+                    }
+                }
+
+                return 0;
+            }
+            finally
+            {
+                if (tempCacheRegistry != null)
+                {
+                    try
+                    {
+                        Directory.Delete(tempCacheRegistry, true);
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+
+        private sealed class ResolvedDependencyInfo
+        {
+            public List<ResolvedDependencyPackage> Packages { get; } = new List<ResolvedDependencyPackage>();
+            public HashSet<string> Dirs { get; } = new HashSet<string>();
+            public Dictionary<string, byte[]> Files { get; } = new Dictionary<string, byte[]>();
+        }
+
+        private struct ResolvedDependencyPackage
+        {
+            public string PackageName { get; }
+            public UniversalPackageVersion Version { get; }
+
+            public ResolvedDependencyPackage(string name, UniversalPackageVersion version)
+            {
+                this.PackageName = name;
+                this.Version = version;
+            }
+        }
+
+        private sealed class DependencyTree
+        {
+            public string PackageName { get; }
+            public UniversalPackageVersion Version { get; }
+            public List<DependencyTree> Dependencies { get; } = new List<DependencyTree>();
+            public HashSet<string> Dirs { get; } = new HashSet<string>();
+            public Dictionary<string, byte[]> Files { get; } = new Dictionary<string, byte[]>();
+
+            public DependencyTree(PackageMetadata metadata)
+            {
+                this.PackageName = metadata.GroupAndName;
+                this.Version = UniversalPackageVersion.Parse(metadata.Version);
+            }
+        }
+
+        private bool CheckOverwrite(ResolvedDependencyInfo resolved)
+        {
+            bool found = false;
+
+            foreach (var name in resolved.Dirs)
+            {
+                if (File.Exists(Path.Combine(this.TargetDirectory, name)))
+                {
+                    Console.Error.WriteLine($"refusing to overwrite file with directory: {name}");
+                    found = true;
+                }
+            }
+
+            foreach (var file in resolved.Files)
+            {
+                if (Directory.Exists(Path.Combine(this.TargetDirectory, file.Key)))
+                {
+                    Console.Error.WriteLine($"refusing to overwrite directory with file: {file.Key}");
+                    found = true;
+                }
+                else if (File.Exists(Path.Combine(this.TargetDirectory, file.Key)))
+                {
+                    Console.Error.WriteLine($"refusing to overwrite file: {file.Key}");
+                    found = true;
+                }
+            }
+
+            return found;
+        }
+
+        private ResolvedDependencyInfo Resolve(DependencyTree tree)
+        {
+            var maxDepth = this.ComputeMaxDepth(tree);
+
+            var info = new ResolvedDependencyInfo();
+            for (var depth = maxDepth; depth >= 0; depth--)
+            {
+                this.GatherPackages(tree, depth, info.Packages);
+            }
+
+            this.MergeContents(info.Dirs, info.Files, tree);
+            return info;
+        }
+
+        private int ComputeMaxDepth(DependencyTree tree)
+        {
+            int depth = 0;
+
+            foreach (var d in tree.Dependencies)
+            {
+                int childDepth = this.ComputeMaxDepth(d);
+                if (childDepth >= depth)
+                {
+                    depth = childDepth + 1;
+                }
+            }
+
+            return depth;
+        }
+
+        private void GatherPackages(DependencyTree tree, int depth, List<ResolvedDependencyPackage> packages)
+        {
+            if (depth > 0)
+            {
+                foreach (var d in tree.Dependencies)
+                {
+                    this.GatherPackages(d, depth - 1, packages);
+                }
+                return;
+            }
+
+            packages.RemoveAll(pkg => string.Equals(pkg.PackageName, tree.PackageName) && pkg.Version == tree.Version);
+            packages.Add(new ResolvedDependencyPackage(tree.PackageName, tree.Version));
+        }
+
+        private void MergeContents(HashSet<string> mergedDirs, Dictionary<string, byte[]> mergedFiles, DependencyTree tree)
+        {
+            var depDirs = new List<HashSet<string>>();
+            var depFiles = new List<Dictionary<string, byte[]>>();
+
+            foreach (var d in tree.Dependencies)
+            {
+                var dirs = new HashSet<string>();
+                var files = new Dictionary<string, byte[]>();
+                try
+                {
+                    this.MergeContents(dirs, files, d);
+                }
+                catch (Exception ex)
+                {
+                    throw new AggregateException($"in dependency of {tree.PackageName}:{tree.Version}: {ex.Message}", ex);
+                }
+                depDirs.Add(dirs);
+                depFiles.Add(files);
+            }
+
+            var fileFrom = new Dictionary<string, int>();
+
+            for (int i = 0; i < depFiles.Count; i++)
+            {
+                var df = depFiles[i];
+                var d = tree.Dependencies[i];
+
+                foreach (var file in df)
+                {
+                    if (tree.Files.ContainsKey(file.Key))
+                    {
+                        continue;
+                    }
+
+                    if (mergedFiles.ContainsKey(file.Key))
+                    {
+                        var existingHash = mergedFiles[file.Key];
+                        if (existingHash.SequenceEqual(file.Value))
+                        {
+                            continue;
+                        }
+
+                        var existing = tree.Dependencies[fileFrom[file.Key]];
+                        throw new InvalidOperationException($"Cannot have both {existing.PackageName}:{existing.Version} and {d.PackageName}:{d.Version} as dependencies of {tree.PackageName}:{tree.Version} as both contain the file {file.Key} with different hashes ({BitConverter.ToString(existingHash)} vs {BitConverter.ToString(file.Value)})");
+                    }
+
+                    mergedFiles[file.Key] = file.Value;
+                    fileFrom[file.Key] = i;
+                }
+            }
+
+            foreach (var file in tree.Files)
+            {
+                mergedFiles[file.Key] = file.Value;
+            }
+
+            var dirFrom = new Dictionary<string, int>();
+
+            foreach (var name in tree.Dirs)
+            {
+                mergedDirs.Add(name);
+            }
+
+            for (int i = 0; i < depDirs.Count; i++)
+            {
+                foreach (var name in depDirs[i])
+                {
+                    if (mergedDirs.Add(name))
+                    {
+                        dirFrom[name] = i;
+                    }
+                }
+            }
+
+            foreach (var name in mergedDirs)
+            {
+                if (mergedFiles.ContainsKey(name))
+                {
+                    var dirTree = dirFrom.ContainsKey(name) ? tree.Dependencies[dirFrom[name]] : tree;
+                    var fileTree = fileFrom.ContainsKey(name) ? tree.Dependencies[fileFrom[name]] : tree;
+                    throw new InvalidOperationException($"Cannot have both a directory from {dirTree.PackageName}:{dirTree.Version} and a file from {fileTree.PackageName}:{fileTree.Version} named {name} in {tree.PackageName}:{tree.Version}");
+                }
+            }
+        }
+
+        private async Task<DependencyTree> BuildTreeAsync(string name, string version, bool prerelease)
+        {
+            PackageMetadata manifest;
+            DependencyTree tree;
+
+            using (var stream = await this.OpenPackageAsync(name, version, prerelease))
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Read, true))
+            {
+                var metadataEntry = zip.GetEntry("upack.json");
+                using (var metadataStream = metadataEntry.Open())
+                {
+                    manifest = await ReadManifestAsync(metadataStream);
+                }
+
+                tree = new DependencyTree(manifest);
+
+                var entries = zip.Entries.Where(e => e.FullName.StartsWith("package/", StringComparison.OrdinalIgnoreCase));
+
+                foreach (var entry in entries)
+                {
+                    var entryName = entry.FullName.Substring("package/".Length).Replace('\\', '/');
+                    if (entryName == "")
+                    {
+                        continue;
+                    }
+
+                    if (entryName.EndsWith("/"))
+                    {
+                        entryName = entryName.TrimEnd('/');
+                        tree.Dirs.Add(entryName);
+                    }
+                    else
+                    {
+                        using (var hash = SHA256.Create())
+                        using (var entryStream = entry.Open())
+                        {
+                            tree.Files[entryName] = hash.ComputeHash(entryStream);
+                        }
+                    }
+
+                    while (true)
+                    {
+                        var i = entryName.LastIndexOf('/');
+                        if (i == -1)
+                        {
+                            break;
+                        }
+                        entryName = entryName.Substring(0, i);
+                        tree.Dirs.Add(entryName);
+                    }
+                }
+            }
+
+            prerelease = !string.IsNullOrEmpty(tree.Version.Prerelease);
+
+            foreach (var d in manifest.Dependencies)
+            {
+                var parts = d.Split(new[]{ ':' }, 3);
+                if (parts.Length == 1)
+                {
+                    name = parts[0];
+                    version = null;
+                }
+                else if (parts.Length == 2)
+                {
+                    if (parts[1] == "*")
+                    {
+                        name = parts[0];
+                        version = null;
+                    }
+                    else
+                    {
+                        var parsedVersion = UniversalPackageVersion.TryParse(parts[1]);
+                        if (parsedVersion != null)
+                        {
+                            name = parts[0];
+                            version = parsedVersion.ToString();
+                        }
+                        else
+                        {
+                            name = parts[0] + "/" + parts[1];
+                            version = null;
+                        }
+                    }
+                }
+                else if (parts.Length == 3)
+                {
+                    name = parts[0] + "/" + parts[1];
+                    if (parts[2] == "*")
+                    {
+                        version = null;
+                    }
+                    else
+                    {
+                        version = parts[2];
+                    }
+                }
+
+                tree.Dependencies.Add(await this.BuildTreeAsync(name, version, prerelease));
+            }
+
+            return tree;
+        }
+
+        private async Task<Stream> OpenPackageAsync(string packageName, string packageVersion, bool prerelease)
+        {
+            string group = null, name = null, version = null;
+
+            var parts = this.PackageName.Split(new[] { ':', '/' });
+            group = parts.Length > 1 ? string.Join("/", new ArraySegment<string>(parts, 0, parts.Length - 1)) : null;
+            name = parts[parts.Length - 1];
+
+            version = await GetVersionAsync(this.SourceUrl, group, name, version, this.Authentication, prerelease);
+
+            if (this.TargetDirectory != null)
+            {
+                await this.registry.RegisterPackageAsync(group, name, UniversalPackageVersion.Parse(version),
+                    this.TargetDirectory, this.SourceUrl, this.Authentication,
+                    this.Comment, null, Environment.UserName);
+            }
+
+            return await this.cache.GetOrDownloadAsync(group, name, UniversalPackageVersion.Parse(version), this.SourceUrl, this.Authentication, true);
+        }
+    }
+}

--- a/upack/CommandDispatcher.cs
+++ b/upack/CommandDispatcher.cs
@@ -8,7 +8,7 @@ namespace Inedo.ProGet.UPack
 {
     public sealed class CommandDispatcher
     {
-        public static CommandDispatcher Default => new CommandDispatcher(typeof(Pack), typeof(Push), typeof(Unpack), typeof(Install), typeof(List));
+        public static CommandDispatcher Default => new CommandDispatcher(typeof(Pack), typeof(Push), typeof(Unpack), typeof(Install), typeof(List), typeof(BuildDependencyTree));
 
         private readonly IEnumerable<Type> commands;
 

--- a/upack/upack.csproj
+++ b/upack/upack.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BuildDependencyTree.cs" />
     <Compile Include="Command.cs" />
     <Compile Include="CommandDispatcher.cs" />
     <Compile Include="Install.cs" />


### PR DESCRIPTION
This will eventually be server-side, but I thought it would be useful to have a prototype implementation that could be used without updating the server.

Dependencies are extracted to the same target directory before the package that depends on them, recursively.

Packages in the tree may contain different versions of the same file if and only if the point where the different versions of the file meet in the dependency tree is a package that also contains that file.

Prints an error message if it cannot resolve a file conflict using the above rule or if any package in the tree contains the same path for a directory as another package contains for a file.

Dependencies with unspecified version numbers are "latest stable" if the package that depends on them is stable and "latest prerelease" if the package that depends on them is prerelease. Whether a package is considered prerelease or stable depends on existence of the prerelease part of the semantic version number.