### PR TITLE
Add --perserve-timestamp option to upack install and upack unpack.

### DIFF
--- a/command.go
+++ b/command.go
@@ -177,7 +177,7 @@ func PrintManifest(info *PackageMetadata) {
 	fmt.Println("Version:", info.Version)
 }
 
-func UnpackZip(targetDirectory string, overwrite bool, zipFile *zip.Reader) error {
+func UnpackZip(targetDirectory string, overwrite bool, zipFile *zip.Reader, perserveTimestamps bool) error {
 	err := os.MkdirAll(targetDirectory, 0777)
 	if err != nil {
 		return err
@@ -215,7 +215,7 @@ func UnpackZip(targetDirectory string, overwrite bool, zipFile *zip.Reader) erro
 			if err != nil {
 				return err
 			}
-			err = saveEntryToFile(entry, targetPath, overwrite)
+			err = saveEntryToFile(entry, targetPath, overwrite, perserveTimestamps)
 			if err != nil {
 				return err
 			}
@@ -228,7 +228,7 @@ func UnpackZip(targetDirectory string, overwrite bool, zipFile *zip.Reader) erro
 	return nil
 }
 
-func saveEntryToFile(entry *zip.File, targetPath string, overwrite bool) (err error) {
+func saveEntryToFile(entry *zip.File, targetPath string, overwrite, perserveTimestamps bool) (err error) {
 	r, err := entry.Open()
 	if err != nil {
 		return
@@ -255,6 +255,17 @@ func saveEntryToFile(entry *zip.File, targetPath string, overwrite bool) (err er
 	}()
 
 	_, err = io.Copy(f, r)
+	if err != nil {
+		return
+	}
+
+	if perserveTimestamps && entry.ModTime().Year() > 1980 {
+		err = os.Chtimes(targetPath, entry.ModTime(), entry.ModTime())
+		if err != nil {
+			return
+		}
+	}
+
 	return
 }
 

--- a/install.go
+++ b/install.go
@@ -10,17 +10,18 @@ import (
 )
 
 type Install struct {
-	PackageName     string
-	Version         string
-	SourceURL       string
-	TargetDirectory string
-	Authentication  *[2]string
-	Overwrite       bool
-	Prerelease      bool
-	Comment         *string
-	UserRegistry    bool
-	Unregistered    bool
-	CachePackages   bool
+	PackageName        string
+	Version            string
+	SourceURL          string
+	TargetDirectory    string
+	Authentication     *[2]string
+	Overwrite          bool
+	Prerelease         bool
+	Comment            *string
+	UserRegistry       bool
+	Unregistered       bool
+	CachePackages      bool
+	PerserveTimestamps bool
 }
 
 func (*Install) Name() string { return "install" }
@@ -127,6 +128,14 @@ func (*Install) ExtraArguments() []ExtraArgument {
 				return &cmd.(*Install).CachePackages
 			}),
 		},
+		{
+			Name:        "perserve-timestamps",
+			Description: "Set extracted file timestamps to the timestamp of the file in the archive instead of the current time.",
+			Flag:        true,
+			TrySetValue: trySetBoolValue("perserve-timestamps", func(cmd Command) *bool {
+				return &cmd.(*Install).PerserveTimestamps
+			}),
+		},
 	}
 }
 
@@ -144,7 +153,7 @@ func (i *Install) Run() int {
 		return 1
 	}
 
-	err = UnpackZip(i.TargetDirectory, i.Overwrite, zip)
+	err = UnpackZip(i.TargetDirectory, i.Overwrite, zip, i.PerserveTimestamps)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/unpack.go
+++ b/unpack.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Unpack struct {
-	Package   string
-	Target    string
-	Overwrite bool
+	Package            string
+	Target             string
+	Overwrite          bool
+	PerserveTimestamps bool
 }
 
 func (*Unpack) Name() string { return "unpack" }
@@ -50,6 +51,14 @@ func (*Unpack) ExtraArguments() []ExtraArgument {
 				return &cmd.(*Unpack).Overwrite
 			}),
 		},
+		{
+			Name:        "perserve-timestamps",
+			Description: "Set extracted file timestamps to the timestamp of the file in the archive instead of the current time.",
+			Flag:        true,
+			TrySetValue: trySetBoolValue("perserve-timestamps", func(cmd Command) *bool {
+				return &cmd.(*Unpack).PerserveTimestamps
+			}),
+		},
 	}
 }
 
@@ -80,7 +89,7 @@ func (u *Unpack) Run() int {
 		return 1
 	}
 
-	err = UnpackZip(u.Target, u.Overwrite, &zipFile.Reader)
+	err = UnpackZip(u.Target, u.Overwrite, &zipFile.Reader, u.PerserveTimestamps)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/upack/Command.cs
+++ b/upack/Command.cs
@@ -213,7 +213,7 @@ namespace Inedo.ProGet.UPack
             Console.WriteLine($"Version: {info.Version}");
         }
 
-        internal static async Task UnpackZipAsync(string targetDirectory, bool overwrite, ZipArchive zipFile)
+        internal static async Task UnpackZipAsync(string targetDirectory, bool overwrite, ZipArchive zipFile, bool perserveTimestamps)
         {
             Directory.CreateDirectory(targetDirectory);
 
@@ -238,6 +238,12 @@ namespace Inedo.ProGet.UPack
                     using (var targetStream = new FileStream(targetPath, overwrite ? FileMode.Create : FileMode.CreateNew, FileAccess.Write, FileShare.None))
                     {
                         await entryStream.CopyToAsync(targetStream);
+                    }
+
+                    // Assume files with timestamps set to 0 (DOS time) or close to 0 are not timestamped.
+                    if (perserveTimestamps && entry.LastWriteTime.Year > 1980)
+                    {
+                        File.SetLastWriteTimeUtc(targetPath, entry.LastWriteTime.DateTime);
                     }
 
                     files++;

--- a/upack/Install.cs
+++ b/upack/Install.cs
@@ -71,14 +71,18 @@ namespace Inedo.ProGet.UPack
         [DefaultValue(false)]
         public bool CachePackages { get; set; } = false;
 
+        [DisplayName("perserve-timestamps")]
+        [Description("Set extracted file timestamps to the timestamp of the file in the archive instead of the current time.")]
+        [ExtraArgument]
+        [DefaultValue(false)]
+        public bool PerserveTimestamps { get; set; } = false;
+
         public override async Task<int> RunAsync()
         {
             using (var stream = await this.OpenPackageAsync())
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Read, true))
             {
-                using (var zip = new ZipArchive(stream, ZipArchiveMode.Read, true))
-                {
-                    await UnpackZipAsync(this.TargetDirectory, this.Overwrite, zip);
-                }
+                await UnpackZipAsync(this.TargetDirectory, this.Overwrite, zip, this.PerserveTimestamps);
             }
 
             return 0;

--- a/upack/Unpack.cs
+++ b/upack/Unpack.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Inedo.ProGet.UPack
@@ -27,6 +25,12 @@ namespace Inedo.ProGet.UPack
         [DefaultValue(false)]
         public bool Overwrite { get; set; } = false;
 
+        [DisplayName("perserve-timestamps")]
+        [Description("Set extracted file timestamps to the timestamp of the file in the archive instead of the current time.")]
+        [ExtraArgument]
+        [DefaultValue(false)]
+        public bool PerserveTimestamps { get; set; } = false;
+
         public override async Task<int> RunAsync()
         {
             using (var zipStream = new FileStream(this.Package, FileMode.Open, FileAccess.Read))
@@ -40,7 +44,7 @@ namespace Inedo.ProGet.UPack
                     PrintManifest(info);
                 }
 
-                await UnpackZipAsync(this.Target, this.Overwrite, zipFile);
+                await UnpackZipAsync(this.Target, this.Overwrite, zipFile, this.PerserveTimestamps);
             }
 
             return 0;


### PR DESCRIPTION
Fixes #16.