### PR TITLE
Deprecate most parameters on repack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Extracts the contents of a ProGet universal package to a directory.
  - **`target`** - Directory where the contents of the package will be extracted.
  - `overwrite` - When specified, overwrite files in the target directory.
 
-
 ### install
 
 Downloads the specified ProGet universal package and extracts its contents to a directory.
@@ -74,7 +73,6 @@ Lists packages installed in the local registry.
     upack list [--userregistry]
 
  - `userregistry` - List packages in the user registry instead of the machine registry.
-
 
 ### repack
 

--- a/README.md
+++ b/README.md
@@ -75,23 +75,18 @@ Lists packages installed in the local registry.
 
  - `userregistry` - List packages in the user registry instead of the machine registry.
 
+
 ### repack
 
-Creates a new ProGet universal package from an existing package with optionally modified metadata.
+Creates a new ProGet universal package by repackaging an existing package with a new version number and audit information.
 
-    upack repack «source» [--manifest=«manifest»] [--targetDirectory=«targetDirectory»] [--group=«group»] [--name=«name»] [--version=«version»] [--title=«title»] [--description=«description»] [--icon=«icon»] [--overwrite]
+    upack repack «source» [--newVersion=«newVersion»] [--targetDirectory=«targetDirectory»] [--note=«auditNote»] [--overwrite] 
 
  - **`source`** - The path of the existing upack file.
- - `manifest` - Path of upack.json file to merge.
- - `targetDirectory` - Directory where the .upack file will be created. If not specified, the current working directory is used.
- - `group` - Package group. If metadata file is provided, value will be ignored.
- - `name` - Package name. If metadata file is provided, value will be ignored.
- - `version` - Package version. If metadata file is provided, value will be ignored.
- - `title` - Package title. If metadata file is provided, value will be ignored.
- - `description` - Package description. If metadata file is provided, value will be ignored.
- - `icon` - Icon absolute Url. If metadata file is provided, value will be ignored.
+ - `newVersion` - New package version to use.
+ - `targetDirectory` - Directory where the .upack file will be created. If not specified, the current working directory is used. 
+ - `note` - A description of the purpose for repackaging that will be entered as the audit note.
  - `overwrite` - Overwrite existing package file if it already exists.
-
 
 ### verify
 

--- a/src/dotnet/upack/Command.cs
+++ b/src/dotnet/upack/Command.cs
@@ -61,6 +61,7 @@ namespace Inedo.ProGet.UPack
                 this.p = p;
             }
 
+            public bool IsDeprecated => p.GetCustomAttribute<ObsoleteAttribute>() != null;
             public abstract bool Optional { get; }
             public string DisplayName => p.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? p.Name;
             public string Description => p.GetCustomAttribute<DescriptionAttribute>()?.Description ?? string.Empty;
@@ -200,12 +201,14 @@ namespace Inedo.ProGet.UPack
 
             foreach (var arg in this.PositionalArguments)
             {
-                s.Append(' ').Append(arg.GetUsage());
+                if (!arg.IsDeprecated)
+                    s.Append(' ').Append(arg.GetUsage());
             }
 
             foreach (var arg in this.ExtraArguments)
             {
-                s.Append(' ').Append(arg.GetUsage());
+                if (!arg.IsDeprecated)
+                    s.Append(' ').Append(arg.GetUsage());
             }
 
             return s.ToString();
@@ -219,12 +222,14 @@ namespace Inedo.ProGet.UPack
 
             foreach (var arg in this.PositionalArguments)
             {
-                s.AppendLine().Append(arg.GetHelp());
+                if (!arg.IsDeprecated)
+                    s.AppendLine().Append(arg.GetHelp());
             }
 
             foreach (var arg in this.ExtraArguments)
             {
-                s.AppendLine().Append(arg.GetHelp());
+                if (!arg.IsDeprecated)
+                    s.AppendLine().Append(arg.GetHelp());
             }
 
             return s.ToString();

--- a/src/dotnet/upack/Repack.cs
+++ b/src/dotnet/upack/Repack.cs
@@ -13,12 +13,12 @@ using Newtonsoft.Json.Linq;
 namespace Inedo.ProGet.UPack
 {
     [DisplayName("repack")]
-    [Description("Creates a new ProGet universal package from an existing package with optionally modified metadata.")]
+    [Description("Creates a new ProGet universal package by repackaging an existing package with a new version number and audit information.")]
     public sealed class Repack : Command
     {
-        [DisplayName("manifest")]
+        [Obsolete]
+        [AlternateName("manifest")]
         [AlternateName("metadata")]
-        [Description("Path of upack.json file to merge.")]
         [ExtraArgument]
         [ExpandPath]
         public string Manifest { get; set; }
@@ -35,44 +35,45 @@ namespace Inedo.ProGet.UPack
         [ExpandPath]
         public string TargetDirectory { get; set; }
 
-        [DisplayName("group")]
-        [Description("Package group. If metadata file is provided, value will be ignored.")]
+        [Obsolete]
+        [AlternateName("group")]
         [ExtraArgument]
         public string Group { get; set; }
 
-        [DisplayName("name")]
-        [Description("Package name. If metadata file is provided, value will be ignored.")]
+        [Obsolete]
+        [AlternateName("name")]
         [ExtraArgument]
         public string Name { get; set; }
 
-        [DisplayName("version")]
-        [Description("Package version. If metadata file is provided, value will be ignored.")]
+        [DisplayName("newVersion")]
+        [AlternateName("version")]
+        [Description("New package version to use.")]
         [ExtraArgument]
-        public string Version { get; set; }
+        public string NewVersion { get; set; }
 
-        [DisplayName("title")]
-        [Description("Package title. If metadata file is provided, value will be ignored.")]
+        [Obsolete]
+        [AlternateName("title")]
         [ExtraArgument]
         public string Title { get; set; }
 
-        [DisplayName("description")]
-        [Description("Package description. If metadata file is provided, value will be ignored.")]
+        [Obsolete]
+        [AlternateName("description")]
         [ExtraArgument]
         public string PackageDescription { get; set; }
 
-        [DisplayName("icon")]
-        [Description("Icon absolute Url. If metadata file is provided, value will be ignored.")]
+        [Obsolete]
+        [AlternateName("icon")]
         [ExtraArgument]
         public string IconUrl { get; set; }
 
-        [DisplayName("no-audit")]
-        [Description("Do not store audit information in the UPack manifest.")]
+        [Obsolete]
+        [AlternateName("no-audit")]
         [ExtraArgument]
         [DefaultValue(false)]
         public bool NoAudit { get; set; }
 
         [DisplayName("note")]
-        [Description("A description of the purpose for creating this upack file.")]
+        [Description("A description of the purpose for repackaging that will be entered as the audit note.")]
         [ExtraArgument]
         public string Note { get; set; }
 
@@ -82,6 +83,7 @@ namespace Inedo.ProGet.UPack
         [DefaultValue(false)]
         public bool Overwrite { get; set; }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         public override async Task<int> RunAsync(CancellationToken cancellationToken)
         {
             if (this.NoAudit && !string.IsNullOrEmpty(this.Note))
@@ -185,7 +187,7 @@ namespace Inedo.ProGet.UPack
                 {
                     Group = this.Group,
                     Name = this.Name,
-                    Version = UniversalPackageVersion.TryParse(this.Version),
+                    Version = UniversalPackageVersion.TryParse(this.NewVersion),
                     Title = this.Title,
                     Description = this.PackageDescription,
                     Icon = this.IconUrl
@@ -206,5 +208,6 @@ namespace Inedo.ProGet.UPack
                 }
             }
         }
+#pragma warning restore CS0612 // Type or member is obsolete
     }
 }

--- a/src/go/upack/command.go
+++ b/src/go/upack/command.go
@@ -163,13 +163,17 @@ func defaultCommandUsage(cmd Command) string {
 	s = append(s, cmd.Name()...)
 
 	for _, arg := range cmd.PositionalArguments() {
-		s = append(s, ' ')
-		s = append(s, arg.Usage()...)
+		if arg.Name != "" {
+			s = append(s, ' ')
+			s = append(s, arg.Usage()...)
+		}
 	}
 
 	for _, arg := range cmd.ExtraArguments() {
-		s = append(s, ' ')
-		s = append(s, arg.Usage()...)
+		if arg.Name != "" {
+			s = append(s, ' ')
+			s = append(s, arg.Usage()...)
+		}
 	}
 
 	return string(s)
@@ -184,13 +188,17 @@ func defaultCommandHelp(cmd Command) string {
 	s = append(s, '\n')
 
 	for _, arg := range cmd.PositionalArguments() {
-		s = append(s, '\n')
-		s = append(s, arg.Help()...)
+		if arg.Name != "" {
+			s = append(s, '\n')
+			s = append(s, arg.Help()...)
+		}
 	}
 
 	for _, arg := range cmd.ExtraArguments() {
-		s = append(s, '\n')
-		s = append(s, arg.Help()...)
+		if arg.Name != "" {
+			s = append(s, '\n')
+			s = append(s, arg.Help()...)
+		}
 	}
 
 	return string(s)

--- a/src/go/upack/repack.go
+++ b/src/go/upack/repack.go
@@ -27,7 +27,7 @@ type Repack struct {
 
 func (*Repack) Name() string { return "repack" }
 func (*Repack) Description() string {
-	return "Creates a new ProGet universal package from an existing package with optionally modified metadata."
+	return "Creates a new ProGet universal package by repackaging an existing package with a new version number and audit information."
 }
 
 func (r *Repack) Help() string  { return defaultCommandHelp(r) }
@@ -49,8 +49,7 @@ func (*Repack) PositionalArguments() []PositionalArgument {
 func (*Repack) ExtraArguments() []ExtraArgument {
 	return []ExtraArgument{
 		{
-			Name:        "manifest",
-			Alias:       []string{"metadata"},
+			Alias:       []string{"manifest", "metadata"},
 			Description: "Path of upack.json file to merge.",
 			TrySetValue: trySetPathValue("manifest", func(cmd Command) *string {
 				return &cmd.(*Repack).Manifest
@@ -64,58 +63,53 @@ func (*Repack) ExtraArguments() []ExtraArgument {
 			}),
 		},
 		{
-			Name:        "group",
-			Description: "Package group. If metadata file is provided, value will be ignored.",
+			Alias: []string{"group"},
 			TrySetValue: trySetStringFnValue("group", func(cmd Command) func(string) {
 				return (&cmd.(*Repack).Metadata).SetGroup
 			}),
 		},
 		{
-			Name:        "name",
-			Description: "Package name. If metadata file is provided, value will be ignored.",
+			Alias: []string{"name"},
 			TrySetValue: trySetStringFnValue("name", func(cmd Command) func(string) {
 				return (&cmd.(*Repack).Metadata).SetName
 			}),
 		},
 		{
-			Name:        "version",
-			Description: "Package version. If metadata file is provided, value will be ignored.",
-			TrySetValue: trySetStringFnValue("version", func(cmd Command) func(string) {
+			Name:        "newVersion",
+			Alias:       []string{"version"},
+			Description: "New package version to use.",
+			TrySetValue: trySetStringFnValue("newVersion", func(cmd Command) func(string) {
 				return (&cmd.(*Repack).Metadata).SetVersion
 			}),
 		},
 		{
-			Name:        "title",
-			Description: "Package title. If metadata file is provided, value will be ignored.",
+			Alias: []string{"title"},
 			TrySetValue: trySetStringFnValue("title", func(cmd Command) func(string) {
 				return (&cmd.(*Repack).Metadata).SetTitle
 			}),
 		},
 		{
-			Name:        "description",
-			Description: "Package description. If metadata file is provided, value will be ignored.",
+			Alias: []string{"description"},
 			TrySetValue: trySetStringFnValue("description", func(cmd Command) func(string) {
 				return (&cmd.(*Repack).Metadata).SetDescription
 			}),
 		},
 		{
-			Name:        "icon",
-			Description: "Icon absolute Url. If metadata file is provided, value will be ignored.",
+			Alias: []string{"icon"},
 			TrySetValue: trySetStringFnValue("icon", func(cmd Command) func(string) {
 				return (&cmd.(*Repack).Metadata).SetIconURL
 			}),
 		},
 		{
 			Name:        "note",
-			Description: "A description of the purpose for creating this upack file.",
+			Description: "A description of the purpose for repackaging that will be entered as the audit note.",
 			TrySetValue: trySetStringValue("note", func(cmd Command) *string {
 				return &cmd.(*Repack).Note
 			}),
 		},
 		{
-			Name:        "no-audit",
-			Description: "Do not store audit information in the UPack manifest.",
-			Flag:        true,
+			Alias: []string{"no-audit"},
+			Flag:  true,
 			TrySetValue: trySetBoolValue("no-audit", func(cmd Command) *bool {
 				return &cmd.(*Repack).NoAudit
 			}),


### PR DESCRIPTION
The parameters still work, but are no longer shown in any documentation.

Fixes #34.