### PR TITLE
Added netcoreapp2.0 support, in a multitargeting configuration

### DIFF
--- a/src/dotnet/upack.nuspec
+++ b/src/dotnet/upack.nuspec
@@ -15,13 +15,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies></dependencies>
     <releaseNotes>https://github.com/Inedo/upack/releases</releaseNotes>
-    <docsUrl>https://inedo.com/support/documentation/various/universal-packages/upack-reference</docsUrl>
-    <packageSourceUrl>https://github.com/Inedo/upack</packageSourceUrl>
-    <bugTrackerUrl>https://github.com/Inedo/upack/issues</bugTrackerUrl>
-    <mailingListUrl>https://inedo.com/support/questions</mailingListUrl>
     <iconUrl>https://inedo.com/company/media/downloads/upack-icon.png</iconUrl>
   </metadata>
   <files>
-    <file src="tools\**" target="tools" />
+    <file src="upack\bin\release\**" target="tools" />
   </files>
 </package>

--- a/src/dotnet/upack/CommandDispatcher.cs
+++ b/src/dotnet/upack/CommandDispatcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/dotnet/upack/ILMergeOrder.txt
+++ b/src/dotnet/upack/ILMergeOrder.txt
@@ -1,4 +1,0 @@
-﻿# this file contains the partial list of the merged assemblies in the merge order
-# you can fill it from the obj\CONFIG\PROJECT.ilmerge generated on every build
-# and finetune merge order to your satisfaction
-

--- a/src/dotnet/upack/packages.config
+++ b/src/dotnet/upack/packages.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="ILMerge" version="2.13.0307" targetFramework="net45" />
-  <package id="Inedo.UPack" version="0.1.0-pre0031" targetFramework="net45" />
-  <package id="MSBuild.ILMerge.Task" version="1.0.5" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
-</packages>

--- a/src/dotnet/upack/upack.csproj
+++ b/src/dotnet/upack/upack.csproj
@@ -1,35 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props" Condition="Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D9A2522F-5256-4383-A55D-529E1D04F2BC}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
+    <Configurations>Debug;Release</Configurations>
     <RootNamespace>Inedo.ProGet.UPack</RootNamespace>
-    <AssemblyName>upack</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <OutputType>Exe</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -50,59 +25,52 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Inedo.UPack, Version=0.1.0.0, Culture=neutral, PublicKeyToken=473f66fe047b59d7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Inedo.UPack.0.1.0-pre0031\lib\net45\Inedo.UPack.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Command.cs" />
-    <Compile Include="CommandDispatcher.cs" />
-    <Compile Include="Hash.cs" />
-    <Compile Include="Install.cs" />
-    <Compile Include="List.cs" />
-    <Compile Include="Metadata.cs" />
-    <Compile Include="Pack.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Push.cs" />
-    <Compile Include="Repack.cs" />
-    <Compile Include="Unpack.cs" />
-    <Compile Include="UpackException.cs" />
-    <Compile Include="Verify.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-    <None Include="ILMerge.props" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="ILMergeOrder.txt" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup />
+
+  <!-- <Import Project="..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props" Condition="Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props')" />
+  <Import Project="..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets" Condition="Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props'))" />
     <Error Condition="!Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets'))" />
-  </Target>
-  <Import Project="..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets" Condition="Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets')" />
+  </Target> -->
   <PropertyGroup>
     <PostBuildEvent>powershell -Command "if (Test-Path C:\Tools -PathType Container) { Copy-Item $(TargetPath) -Destination C:\Tools\upack.exe -Force }"</PostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup>
+    <id>upack</id>
+    <title>upack command line client</title>
+    <version>0.0.0</version>
+    <authors>Inedo</authors>
+    <owners>Inedo</owners>
+    <summary>Command-line client for ProGet Universal feeds.</summary>
+    <description>upack is a simple CLI tool for building, installing, and publishing universal packages to ProGet feeds.</description>
+    <projectUrl>https://inedo.com/upack</projectUrl>
+    <tags>proget upack universal</tags>
+    <copyright>Inedo 2017</copyright>
+    <licenseUrl>https://github.com/Inedo/upack/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies></dependencies>
+    <releaseNotes>https://github.com/Inedo/upack/releases</releaseNotes>
+    <docsUrl>https://inedo.com/support/documentation/various/universal-packages/upack-reference</docsUrl>
+    <packageSourceUrl>https://github.com/Inedo/upack</packageSourceUrl>
+    <bugTrackerUrl>https://github.com/Inedo/upack/issues</bugTrackerUrl>
+    <mailingListUrl>https://inedo.com/support/questions</mailingListUrl>
+    <iconUrl>https://inedo.com/company/media/downloads/upack-icon.png</iconUrl>
+  </PropertyGroup>
+  <ItemGroup>
+   <!-- <PackageReference Include="ILMerge" Version="2.14.1208" /> -->
+    
+    <PackageReference Include="Inedo.UPack" Version="1.0.0" />
+    <!-- <PackageReference Include="MSBuild.ILMerge.Task" Version="1.0.5" /> -->
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <None Include="App.config" />
+    
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi,

made some changes to allow running on .netstandard.  This allows running on linux/mac without go.

May want to hold on with the merge on this one.  Does not run on mac because of a problem in the shared dependency Inedo.UPack.Packaging.PackageRegistry. There this code

```
public static string GetMachineRegistryRoot()
{
      return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "upack");
}
```
causes problems -- SpecialFolder.CommonApplication data maps to /usr/share -- on the mac, this folder is in special lockdown mode, so another folder should be chosen.

```
if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
{
    Console.WriteLine("We're not on Windows anymore");
}
```