### PR TITLE
Adding the version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,9 @@ Displays metadata for a remote universal package.
  - **`source`** - URL of a upack API endpoint. If not specified, the `UPACK_FEED` environment variable is used.
  - `user` - Credentials to use for servers that require authentication. This can be either `«username»:«password»` or `api:«api-key»`. If not specified, the `UPACK_USER` environment variable is used.
  - `file` - The metadata file to display relative to the .upack root; the default is upack.json.
+
+### version
+
+Outputs the installed version of upack.
+
+    upack version

--- a/src/dotnet/upack/CommandDispatcher.cs
+++ b/src/dotnet/upack/CommandDispatcher.cs
@@ -10,7 +10,7 @@ namespace Inedo.UPack.CLI
 {
     public sealed class CommandDispatcher
     {
-        public static CommandDispatcher Default => new CommandDispatcher(typeof(Pack), typeof(Push), typeof(Unpack), typeof(Install), typeof(List), typeof(Repack), typeof(Verify), typeof(Hash), typeof(Metadata), typeof(Get));
+        public static CommandDispatcher Default => new CommandDispatcher(typeof(Pack), typeof(Push), typeof(Unpack), typeof(Install), typeof(List), typeof(Repack), typeof(Verify), typeof(Hash), typeof(Metadata), typeof(Get), typeof(Version));
 
         private readonly IEnumerable<Type> commands;
 

--- a/src/dotnet/upack/Version.cs
+++ b/src/dotnet/upack/Version.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Inedo.UPack.CLI
+{
+    [DisplayName("version")]
+    [Description("Outputs the installed version of upack.")]
+    public class Version : Command
+    {
+        public override Task<int> RunAsync(CancellationToken cancellationToken)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+            var version = fvi.FileVersion;
+
+            Console.WriteLine(version);
+
+            return Task.FromResult(0);
+        }
+    }
+}


### PR DESCRIPTION
I believe this is really trivial to any command line utility to have the ability to get the version.

I did not change the Assembly version (currently 0.0.0.0), but I believe the Inedo team can handle it in the next release of software (add the according Assembly version).

Our use case is that we have a tool that checks every installed tools for TeamCity agents for updates.

Without this PR, I would have to take the output of 'upack', select the version in the first row. Although that could work, I believe it is better to have a specific command for it. All the other tools (node, npm, dotnet cli, etc) has a  `-v` or `-version`, therefore `upack version` seems appropriate.