### PR TITLE
Implemented filter by prerelease (fixes #64)

### DIFF
--- a/src/upack/Command.cs
+++ b/src/upack/Command.cs
@@ -389,7 +389,10 @@ namespace Inedo.UPack.CLI
             if (!versions.Any())
                 throw new UpackException($"No versions of package {id} found.");
 
-            return versions.Max(v => v.Version);
+            var matchingVersions = versions.Where(v => v.Version.Prerelease != null == prerelease).ToArray();
+            if (!matchingVersions.Any())
+                throw new UpackException($"No {(prerelease ? "pre" : "")}release versions of package {id} found.");
+            return matchingVersions.Max(v => v.Version);
         }
 
         internal const string PackageNotFoundMessage = "The specified universal package was not found at the given URL";


### PR DESCRIPTION
This fixes #64 . I've tested this locally for `upack install` for installing either the latest prerelease or release version of a package.

Looking at the code, this seems to also affect `upack get`.